### PR TITLE
Fix missing or unreadable manifest file

### DIFF
--- a/animal-sounds-facts/manifest.json
+++ b/animal-sounds-facts/manifest.json
@@ -6,11 +6,5 @@
   "action": {
     "default_title": "Animal Sounds & Facts",
     "default_popup": "popup.html"
-  },
-  "icons": {
-    "16": "images/icon-16.png",
-    "32": "images/icon-32.png",
-    "48": "images/icon-48.png",
-    "128": "images/icon-128.png"
   }
 }


### PR DESCRIPTION
Remove the `icons` section from `manifest.json` because the referenced files were missing, which would cause follow-up errors when loading the extension.

---
<a href="https://cursor.com/background-agent?bcId=bc-4adee629-1ccc-41ed-852d-f01afd93f0f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4adee629-1ccc-41ed-852d-f01afd93f0f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

