### PR TITLE
Fix manifest json readability

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,10 @@
 {
   "name": "Animal Explorer",
   "short_name": "Animals",
+  "description": "Explore animals with images, sounds, and categories.",
+  "id": ".",
   "start_url": ".",
+  "scope": ".",
   "display": "standalone",
   "background_color": "#0b1220",
   "theme_color": "#4e9cff",


### PR DESCRIPTION
Add `description`, `id`, and `scope` fields to `manifest.json` to improve clarity and PWA compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4ff8c7e-5d68-4f85-920e-f241ed5e67c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4ff8c7e-5d68-4f85-920e-f241ed5e67c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

