### PR TITLE
Fix invalid extension icons manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,27 +1,24 @@
 {
-  "name": "Animal Explorer",
-  "short_name": "Animals",
-  "description": "Explore animals with images, sounds, and categories.",
-  "id": ".",
-  "version": "1.0.0",
   "manifest_version": 3,
-  "start_url": ".",
-  "scope": ".",
-  "display": "standalone",
-  "background_color": "#0b1220",
-  "theme_color": "#4e9cff",
-  "icons": [
+  "name": "Animal Explorer",
+  "version": "1.0.0",
+  "description": "Explore animals with images, sounds, and categories.",
+  "action": {
+    "default_popup": "index.html",
+    "default_title": "Animal Explorer"
+  },
+  "web_accessible_resources": [
     {
-      "src": "icons/icon-192.svg",
-      "sizes": "192x192",
-      "type": "image/svg+xml",
-      "purpose": "any"
-    },
-    {
-      "src": "icons/icon-512.svg",
-      "sizes": "512x512",
-      "type": "image/svg+xml",
-      "purpose": "any"
+      "resources": [
+        "assets/*",
+        "icons/*",
+        "css/*",
+        "js/*",
+        "data/*"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Convert `manifest.json` to a valid Chrome Extension MV3 format to fix 'Invalid value for icons' error and allow the extension to load.

---
<a href="https://cursor.com/background-agent?bcId=bc-147454c0-62cd-4185-bcd5-458940414442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-147454c0-62cd-4185-bcd5-458940414442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

