### PR TITLE
Fix missing animal images

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -133,6 +133,12 @@
 
     img.src = animal.image;
     img.alt = `${animal.name} (${resolveCategoryName(animal.category)})`;
+    img.referrerPolicy = 'no-referrer';
+    img.onerror = () => {
+      if (img.dataset.fallback === '1') return;
+      img.dataset.fallback = '1';
+      img.src = `https://placehold.co/800x600?text=${encodeURIComponent(animal.name)}`;
+    };
     name.textContent = animal.name;
     pill.textContent = resolveCategoryName(animal.category);
 
@@ -159,6 +165,12 @@
   function openModal(animal) {
     modalImgEl.src = animal.image;
     modalImgEl.alt = animal.name;
+    modalImgEl.referrerPolicy = 'no-referrer';
+    modalImgEl.onerror = () => {
+      if (modalImgEl.dataset.fallback === '1') return;
+      modalImgEl.dataset.fallback = '1';
+      modalImgEl.src = `https://placehold.co/1200x800?text=${encodeURIComponent(animal.name)}`;
+    };
     modalTitleEl.textContent = animal.name;
     modalCategoryEl.textContent = resolveCategoryName(animal.category);
     modalBodyEl.innerHTML = '';

--- a/gallery.html
+++ b/gallery.html
@@ -147,7 +147,9 @@
           img.referrerPolicy = 'no-referrer';
           img.src = imageUrl;
           img.onerror = () => {
-            img.alt = `${name} image failed to load`;
+            if (img.dataset.fallback === '1') return;
+            img.dataset.fallback = '1';
+            img.src = `https://placehold.co/800x600?text=${encodeURIComponent(name)}`;
           };
 
           const meta = document.createElement('div');

--- a/js/app.js
+++ b/js/app.js
@@ -137,7 +137,7 @@
       figure.className = 'card';
       figure.innerHTML = `
         <div class="card-media">
-          <img src="${escapeHtml(firstAnimal.imageUrl)}" alt="${escapeHtml(category.name)} cover" loading="lazy">
+          <img src="${escapeHtml(firstAnimal.imageUrl)}" alt="${escapeHtml(category.name)} cover" loading="lazy" referrerpolicy="no-referrer" onerror="if(!this.dataset.fallback){this.dataset.fallback='1'; this.src='https://placehold.co/800x600?text=${encodeURIComponent(category.name)}';}">
         </div>
         <div class="chip">${category.animals.length} animals</div>
         <div class="card-title">${escapeHtml(category.name)}</div>
@@ -160,7 +160,7 @@
       card.setAttribute('tabindex', '0');
       card.innerHTML = `
         <div class="card-media">
-          <img src="${escapeHtml(animal.imageUrl)}" alt="${escapeHtml(animal.name)}" loading="lazy">
+          <img src="${escapeHtml(animal.imageUrl)}" alt="${escapeHtml(animal.name)}" loading="lazy" referrerpolicy="no-referrer" onerror="if(!this.dataset.fallback){this.dataset.fallback='1'; this.src='https://placehold.co/800x600?text=${encodeURIComponent(animal.name)}';}">
         </div>
         <div class="card-title">${escapeHtml(animal.name)}</div>
       `;
@@ -181,6 +181,12 @@
     els.modalTitle.textContent = animal.name;
     els.modalImage.src = animal.imageUrl;
     els.modalImage.alt = `${animal.name} large photo`;
+    els.modalImage.referrerPolicy = 'no-referrer';
+    els.modalImage.onerror = () => {
+      if (els.modalImage.dataset.fallback === '1') return;
+      els.modalImage.dataset.fallback = '1';
+      els.modalImage.src = `https://placehold.co/1200x800?text=${encodeURIComponent(animal.name)}`;
+    };
     els.modalText.innerHTML = animal.description.map(p => `<p>${escapeHtml(p)}</p>`).join('');
 
     if (state.audio) { try { state.audio.pause(); } catch {} }


### PR DESCRIPTION
Add image fallbacks and referrer policies to ensure all animal images display, preventing blank spaces on failed loads.

---
<a href="https://cursor.com/background-agent?bcId=bc-81d4e306-3fb1-4169-9de9-196bae5ea4de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81d4e306-3fb1-4169-9de9-196bae5ea4de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

