### PR TITLE
Add missing animal images

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -113,9 +113,9 @@
   function setImageWithFallback(img, primaryUrl, name, width = 800, height = 600) {
     const placeholder = `https://placehold.co/${width}x${height}?text=${encodeURIComponent(name || 'Image')}`;
     const candidates = [];
-    if (primaryUrl) candidates.push(primaryUrl);
     const wm = buildWikimediaFallbackUrl(primaryUrl, Math.max(width, 800));
     if (wm) candidates.push(wm);
+    if (primaryUrl) candidates.push(primaryUrl);
     let index = 0;
     img.referrerPolicy = 'no-referrer';
     const tryNext = () => {

--- a/gallery.html
+++ b/gallery.html
@@ -132,9 +132,9 @@
     function setImageWithFallback(img, primaryUrl, name, width = 800, height = 600) {
       const placeholder = `https://placehold.co/${width}x${height}?text=${encodeURIComponent(name || 'Image')}`;
       const candidates = [];
-      if (primaryUrl) candidates.push(primaryUrl);
       const wm = buildWikimediaFallbackUrl(primaryUrl, Math.max(width, 800));
       if (wm) candidates.push(wm);
+      if (primaryUrl) candidates.push(primaryUrl);
       let index = 0;
       img.referrerPolicy = 'no-referrer';
       const tryNext = () => {

--- a/js/app.js
+++ b/js/app.js
@@ -92,9 +92,9 @@
   function setImageWithFallback(img, primaryUrl, name, width = 800, height = 600) {
     const placeholder = `https://placehold.co/${width}x${height}?text=${encodeURIComponent(name || 'Image')}`;
     const candidates = [];
-    if (primaryUrl) candidates.push(primaryUrl);
     const wm = buildWikimediaFallbackUrl(primaryUrl, Math.max(width, 800));
     if (wm) candidates.push(wm);
+    if (primaryUrl) candidates.push(primaryUrl);
     let index = 0;
     img.referrerPolicy = 'no-referrer';
     const tryNext = () => {


### PR DESCRIPTION
Prioritize Wikimedia's Special:FilePath in image fallback to fix broken image links.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d57db3c-5de4-4b79-8dff-d86a97c74a68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d57db3c-5de4-4b79-8dff-d86a97c74a68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

