### PR TITLE
Handle sound playback errors with fallback

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -253,9 +253,11 @@
       audioEl.muted = isMuted;
       // Always start from the beginning for quick feedback
       try { audioEl.currentTime = 0; } catch {}
-      await audioEl.play();
-    } catch (err) {
-      console.error(err);
+      const playPromise = audioEl.play();
+      if (playPromise && typeof playPromise.catch === 'function') {
+        playPromise.catch(() => { try { synthBeep(); } catch {} });
+      }
+    } catch {
       // Network or playback failed; provide audible feedback anyway
       try { await synthBeep(); } catch {}
     }


### PR DESCRIPTION
Handle `audioEl.play()` promise rejections to prevent DOMExceptions and ensure a fallback sound.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf98b13c-754d-4843-820a-76ed4025f9b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf98b13c-754d-4843-820a-76ed4025f9b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

