### PR TITLE
Fix CORS error for audio access

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -20,7 +20,9 @@
   /** @type {HTMLAudioElement} */
   const audioEl = new Audio();
   audioEl.preload = 'auto';
-  audioEl.crossOrigin = 'anonymous';
+  // Avoid forcing a CORS fetch which can fail for some third-party hosts
+  // Keep playback simple; we don't pipe this element into WebAudio
+  audioEl.referrerPolicy = 'no-referrer';
   let currentCategory = 'all';
   let isMuted = false;
   // Reusable AudioContext for synthesized fallback tones

--- a/gallery.html
+++ b/gallery.html
@@ -117,7 +117,8 @@
     // Reusable audio element for playing animal sounds on click
     const audioEl = new Audio();
     audioEl.preload = 'auto';
-    audioEl.crossOrigin = 'anonymous';
+    // Do not force CORS for third-party audio; avoid blocked requests
+    audioEl.referrerPolicy = 'no-referrer';
 
     function buildWikimediaFallbackUrl(url, width) {
       try {


### PR DESCRIPTION
Remove `crossOrigin='anonymous'` from audio elements and add `referrerPolicy='no-referrer'` to fix CORS errors for Wikimedia audio.

The `crossOrigin='anonymous'` attribute forced a CORS-enabled fetch, which Wikimedia's servers blocked for the chrome-extension origin. Removing it allows the browser to fetch audio without triggering a CORS preflight, while `referrerPolicy='no-referrer'` prevents potential referrer-related denials.

---
<a href="https://cursor.com/background-agent?bcId=bc-54d79ca3-a01f-41ae-b5eb-da34155129a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-54d79ca3-a01f-41ae-b5eb-da34155129a4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

